### PR TITLE
BOM-45: deploy to PyPi and drop Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,40 @@
 language: python
+
 sudo: false
+
 cache: pip
+
 matrix:
   include:
-    - python: 3.6
-      env: TOXENV=py3
-    - python: 3.6
-      env: TOXENV=pycodestyle
-    - python: 3.6
-      env: TOXENV=pylint
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 2.7
-      env: TOXENV=pycodestyle
-    - python: 2.7
-      env: TOXENV=pylint
+  - python: 3.5
+    env: TOXENV=py3
+  - python: 3.5
+    env: TOXENV=quality
+
 addons:
-    apt:
-        packages:
-            - libblas-dev
-            - liblapack-dev
-            - gfortran
+  apt:
+    packages:
+    - libblas-dev
+    - liblapack-dev
+    - gfortran
+
 install:
-    - pip install tox
-    - pip install coveralls
+  - pip install tox
+  - pip install coveralls
+
 script:
-    - make test
+  - make test
+
 after_success:
-    - coveralls
-branches:
-    only:
-      - master
+  - coveralls
+
+deploy:
+  provider: pypi
+  user: "__token__"
+  password:
+    secure: G3Z+PwXTi3BwSXSqhGGpxq5UMcKKwdpb37YRfd2ekrLZW+bPhIMpgudBdlWN64XnCFxgE68BSZC3eueIisHe+cx5wUyGifxuJHrDCjkJcOu5fp7er4n1aBs6jSBsv6AzjkWgGBvm7BozgDWzxkx1eKwPQPYX0tTj9LRxXkuYa0tMCd0FSM4awh4ccysHfVqJmnDnNNJbNk+7XuM2R7tWLU08X6IJ9c4lmuf8vrYV4tih6l+pkP1kkdI34zO0JuirhilSRNOk2/LakiCtiFL9k9wLDsDbREOzPyTK3CzN4QeieMdw8HMnx3zvTH6HmrUaZXsg2y6nrIPtJGRriFq8GvPt3qp410SxFKBeaOwjbiGue5BrDWEK962gYkpeXVhPcCsz/RYCG4viuFivwM/qfMX7PKFGZ44W267T2XAiItju4KzFzih2x/T5oTAOO9wFzCCk7DzEPU8qw7OaTKMufTG5M3aHrgztXHTafL1uQv+MoxSYa6becQdIHNRWTeTU1dSPzvLG0Se1wJum9laAXXxt3WJcG35d7WES39Lam+ZlxKOFifqgNCetYwckQF7mp7R6ap+NLcRVDdecghuCxrmR3ykerU8sN+XeFVssUCdgJvSqZFZaDUFv1tTTIvOWBKdlXgxgaPOnNPi1O4UroH/BwFhoKppTbTXJkw3h3Y4=
+  distributions: sdist bdist_wheel
+  on:
+    tags: true
+    python: 3.5
+    condition: "$TOXENV = quality"

--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,15 @@
 openedx-calc
 ============
 
-A helper library for mathematical calculations,
-used by the `edx-platform`_.
+A helper library for mathematical calculations, used by the `edx-platform`_.
 
-This code originally lived in the `edx-platform`_ repo,
-but now exists here independently.
+This code originally lived in the `edx-platform`_ repo, but now exists here independently.
 
 
 License
 -------
 
-The code in this repository is licensed under version 3 of the AGPL
-unless otherwise noted. Please see the `LICENSE`_ file for details.
+The code in this repository is licensed under version 3 of the AGPL unless otherwise noted. Please see the `LICENSE`_ file for details.
 
 
 .. _edx-platform: https://github.com/edx/edx-platform

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,44 @@
-from __future__ import absolute_import
+import os
 from setuptools import setup
 
 
+README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+
 setup(
     name="calc",
-    version='0.4',
-    packages=["calc"],
+    version='1.0.0',
+    description='A helper library for mathematical calculations, used by Open edX.',
+    long_description=README,
+    author='edX',
+    author_email='oscm@edx.org',
+    url='https://github.com/edx/openedx-calc',
+    packages=[
+        'calc'
+    ],
+    include_package_data=True,
     install_requires=[
         "pyparsing==2.2.0",
         "numpy",
         "scipy",
         'six',
     ],
+    python_requires=">=3.5",
+    license="AGPL 3.0",
     test_suite='calc.tests',
     tests_require=[
         'coverage',
+    ],
+    zip_safe=False,
+    keywords='edx',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3,pycodestyle,pylint
+envlist = py3,quality
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
@@ -11,16 +11,11 @@ commands =
     coverage run setup.py test
     coverage report
 
-[testenv:pycodestyle]
+[testenv:quality]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     pycodestyle
-commands =
-    pycodestyle calc/__init__.py calc/tests/__init__.py
-
-[testenv:pylint]
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-deps =
     pylint
 commands =
+    pycodestyle calc/__init__.py calc/tests/__init__.py
     pylint calc/tests/__init__.py


### PR DESCRIPTION
- Deploy to PyPI
- Drop Python 2.7 support
- Create quality tox env

BOM-45