### PR TITLE
BOM-45: fix deploy to PyPI (take 4)

### DIFF
--- a/calc/__init__.py
+++ b/calc/__init__.py
@@ -5,3 +5,5 @@ backwards compatibility
 """
 from __future__ import absolute_import
 from .calc import *
+
+__version__ = '1.0.2'  # pragma: no cover

--- a/calc/__init__.py
+++ b/calc/__init__.py
@@ -5,5 +5,3 @@ backwards compatibility
 """
 from __future__ import absolute_import
 from .calc import *
-
-__version__ = '1.0.2'  # pragma: no cover

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,7 +1,6 @@
 # openedx.yaml
 
 ---
-nick: openedx-calc
 oeps:
     oep-7: false
     oep-18: false

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,4 +1,7 @@
+# openedx.yaml
 
+---
+nick: openedx-calc
 oeps:
     oep-7: false
     oep-18: false

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,14 @@
 import os
 from setuptools import setup
 
-from calc import __version__
-
 README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+
 
 setup(
     name="openedx-calc",
-    version=__version__,
+    # Note: cannot easily move version to calc/__init__.py because it imports all
+    #   of calc, which causes failure here when requirements have not yet been loaded.
+    version='1.0.2',
     description='A helper library for mathematical calculations, used by Open edX.',
     long_description=README,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 import os
 from setuptools import setup
 
+from calc import __version__
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 
 setup(
-    name="calc",
-    version='1.0.2',
+    name="openedx-calc",
+    version=__version__,
     description='A helper library for mathematical calculations, used by Open edX.',
     long_description=README,
+    long_description_content_type="text/x-rst",
     author='edX',
     author_email='oscm@edx.org',
     url='https://github.com/edx/openedx-calc',


### PR DESCRIPTION
Jenkins job failed with the following error:
> HTTPError: 403 Client Error: The user '****' isn't allowed to upload to project 'calc'. See https://pypi.org/help/#project-name for more information. for url: https://upload.pypi.org/legacy/
Is this the right fix?

- updated name of package to not conflict with an existing package on
PyPI.
- moved version to where it is typically found in other repos.
- updated long description format.

BOM-45