### PR TITLE
chore: silence deprecation warning: numpy.complex

### DIFF
--- a/calc/calc.py
+++ b/calc/calc.py
@@ -71,8 +71,8 @@ DEFAULT_FUNCTIONS = {
 }
 
 DEFAULT_VARIABLES = {
-    'i': numpy.complex(0, 1),
-    'j': numpy.complex(0, 1),
+    'i': complex(0, 1),
+    'j': complex(0, 1),
     'e': numpy.e,
     'pi': numpy.pi,
 }


### PR DESCRIPTION
"DeprecationWarning: `np.complex` is a deprecated alias for the builtin
`complex`. To silence this warning, use `complex` by itself. Doing this
will not modify any behavior and is safe. If you specifically wanted the
numpy scalar type, use `np.complex128` here."